### PR TITLE
Allow to properly dump the multiples PRs

### DIFF
--- a/src/stacky/stacky.py
+++ b/src/stacky/stacky.py
@@ -30,7 +30,7 @@ import shlex
 import subprocess
 import sys
 from argparse import ArgumentParser
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import asciitree
 import colors
@@ -246,7 +246,11 @@ def get_pr_info(branch, *, full=False):
     infos = {info["id"]: info for info in infos}
     open_prs = [info for info in infos.values() if info["state"] == "OPEN"]
     if len(open_prs) > 1:
-        die("Branch {} has more than one open PR: {}", branch, ", ".join(open_prs))
+        die(
+            "Branch {} has more than one open PR: {}",
+            branch,
+            ", ".join([str(pr) for pr in open_prs]),
+        )
     return infos, open_prs[0] if open_prs else None
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[flake8]
+ignore = D203, E501, W503, E203
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-complexity = 10
+max-line-length = 120


### PR DESCRIPTION
## Summary
If there is more than one PRs open_prs is a list of dict and trying to
stringify it is not working too well:

Traceback (most recent call last):
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 1542, in <module>
    main()
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 1529, in main
    args.func(stack, args)
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 1042, in cmd_update
    load_pr_info_for_forest(forest)
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 531, in load_pr_info_for_forest
    b.load_pr_info()
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 303, in load_pr_info
    self.pr_info, self.open_pr_info = get_pr_info(self.name)
  File "/data/home/mpatou/Rockset/rs/../rs2/scripts/stacky", line 251, in get_pr_info
    die("Branch {} has more than one open PR: {}", branch, ", ".join(open_prs))
TypeError: sequence item 0: expected str instance, dict found

## Test plan
Reran with the fix and got this instead:
```
2023-12-16 18:48:39,690 stacky ERROR: Branch master has more than one open PR: {'baseRefName': 'master', 'headRefName': 'master', 'id': 'PR_kwDOCQXGIM5CfHq6', 'mergeable': 'MERGEABLE', 'number': 303, 'state': 'OPEN', 'title': 'cc_library support resolve directive', 'url': 'https://github.com/stackb/rules_proto/pull/303'}, {'baseRefName': 'master', 'headRefName': 'master', 'id': 'PR_kwDOCQXGIM4x4YnZ', 'mergeable': 'CONFLICTING', 'number': 213, 'state': 'OPEN', 'title': 'fix: allow generated files to be in a subfolder', 'url': 'https://github.com/stackb/rules_proto/pull/213'}
```

Reviewers: tudor
