### PR TITLE
Fix issues when pushing sub stack to a different repo

### DIFF
--- a/src/stacky/stacky.py
+++ b/src/stacky/stacky.py
@@ -783,7 +783,9 @@ def create_gh_pr(b: StackBranch, prefix: str):
     cout("Creating PR for {}\n", b.name, fg="green")
     parent_prefix = ""
     if b.parent.name not in STACK_BOTTOMS:
-        parent_prefix = prefix
+        # you are pushing a sub stack, there is no way we can make it work
+        # accross repo so we will push within your own clone
+        prefix = ""
     cmd = [
         "gh",
         "pr",


### PR DESCRIPTION
## Summary
Pushing to a substack (ie. a branch that is not directly merging to
master/main) is not working accross repository as there is no way to
create a branch in `main_repo` where `branch_B` would merge in
`branch_A`.

So instead create a PR for the forked repository, it's not an ideal
situation but at least it allows to run tests (mostly) and potentially
to have proper discussion on the PR.

## Tests

Used this version to submit PRs accross repo, also testing in Github.
